### PR TITLE
Feature/auth decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BobLobLaw
 
-BobLobLaw is an application developed for learning purposes, that is, the main intention of the project is to learn web development techniques and best practices. The concrete goal is to build and serve a system that is simple, safe and stable, allowing user registration and login.
+BobLobLaw is an application developed for learning purposes, i.e. the main intention of the project is to learn web development techniques and best practices. The concrete goal is to build and serve a system that is simple, safe and stable, allowing user registration and login.
 In the back-end, I build upon Django framework an API that serves the front-end, an interface built with React.
 Python version: 3.8.5+
 

--- a/accounts/auth_tools/auth_decorator.py
+++ b/accounts/auth_tools/auth_decorator.py
@@ -1,11 +1,14 @@
+from functools import wraps
 from django.http import JsonResponse
 
 
-def login_required(endpoint, *args, **kwargs):
-    user = kwargs.get("user")
-    if user != None:
-        return endpoint
-    else:
-        response = JsonResponse({"error": ["Forbidden."]})
-        response.status_code = 403
-        return response
+def login_required(endpoint):
+    @wraps(endpoint)
+    def _wrapped_view(self, request, *args, **kwargs):
+        if request.user != None:
+            return endpoint(self, request, *args, **kwargs)
+        else:
+            response = JsonResponse({"error": ["Forbidden."]})
+            response.status_code = 403
+            return response
+    return _wrapped_view

--- a/accounts/auth_tools/auth_decorator.py
+++ b/accounts/auth_tools/auth_decorator.py
@@ -1,5 +1,11 @@
+from django.http import JsonResponse
 
 
-def login_required(func, request):
-    if request.user != None:
-        return func
+def login_required(endpoint, *args, **kwargs):
+    user = kwargs.get("user")
+    if user != None:
+        return endpoint
+    else:
+        response = JsonResponse({"error": ["Forbidden."]})
+        response.status_code = 403
+        return response

--- a/accounts/auth_tools/auth_decorator.py
+++ b/accounts/auth_tools/auth_decorator.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from django.http import JsonResponse
+from django.http import HttpResponse
 
 
 def login_required(endpoint):
@@ -8,7 +8,7 @@ def login_required(endpoint):
         if request.user != None:
             return endpoint(self, request, *args, **kwargs)
         else:
-            response = JsonResponse({"error": ["Forbidden."]})
-            response.status_code = 403
+            response = HttpResponse()
+            response.status_code = 401
             return response
     return _wrapped_view

--- a/accounts/auth_tools/auth_middleware.py
+++ b/accounts/auth_tools/auth_middleware.py
@@ -11,19 +11,12 @@ class AuthenticationMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-
-        if request.path == "/accounts/signin/" or request.path == "/accounts/signup/":
-            return self.get_response(request)
-        # When user makes get requests to signin or signup, this midd should not respond with error
-
         try:
-            # if not public:
             access_token = json.loads(request.body.decode()).get("access_token")
             user_id = jwt.decode(access_token, Signer().sign("JWT"), algorithms=["HS256"]).get("sub")
             user = User.objects.get(id=user_id)
             request.user = user.id
             response = self.get_response(request)
-            # else responds with view (e.g. get signup or signin)
         except User.DoesNotExist:
             request.user = None
             response = self.get_response(request)

--- a/accounts/auth_tools/auth_middleware.py
+++ b/accounts/auth_tools/auth_middleware.py
@@ -12,8 +12,8 @@ class AuthenticationMiddleware:
 
     def __call__(self, request):
 
-        # if request.path == "/accounts/signin/" or request.path == "/accounts/signup/":
-        #     return self.get_response(request)
+        if request.path == "/accounts/signin/" or request.path == "/accounts/signup/":
+            return self.get_response(request)
         # When user makes get requests to signin or signup, this midd should not respond with error
 
         try:
@@ -26,8 +26,14 @@ class AuthenticationMiddleware:
             # else responds with view (e.g. get signup or signin)
         except User.DoesNotExist:
             request.user = None
-            response = self.get_response(request)            
-        except (jwt.exceptions.DecodeError, jwt.exceptions.ExpiredSignatureError, json.decoder.JSONDecodeError):
-            response = HttpResponse()
-            response.status_code = 401
+            response = self.get_response(request)
+        except jwt.exceptions.DecodeError:
+            request.user = None
+            response = self.get_response(request)
+        except jwt.exceptions.ExpiredSignatureError:
+            request.user = None
+            response = self.get_response(request)
+        except json.decoder.JSONDecodeError:
+            request.user = None
+            response = self.get_response(request)
         return response

--- a/accounts/auth_tools/auth_middleware.py
+++ b/accounts/auth_tools/auth_middleware.py
@@ -14,13 +14,16 @@ class AuthenticationMiddleware:
 
         # if request.path == "/accounts/signin/" or request.path == "/accounts/signup/":
         #     return self.get_response(request)
+        # When user makes get requests to signin or signup, this midd should not respond with error
 
         try:
+            # if not public:
             access_token = json.loads(request.body.decode()).get("access_token")
             user_id = jwt.decode(access_token, Signer().sign("JWT"), algorithms=["HS256"]).get("sub")
             user = User.objects.get(id=user_id)
             request.user = user.id
             response = self.get_response(request)
+            # else responds with view (e.g. get signup or signin)
         except User.DoesNotExist:
             request.user = None
             response = self.get_response(request)            

--- a/accounts/tests/test_auth_decorator.py
+++ b/accounts/tests/test_auth_decorator.py
@@ -1,15 +1,38 @@
+import json
+from rstr import rstr, letters, nonwhitespace
+
 from django.test import Client, TestCase, RequestFactory
 from django.urls import reverse
 
 from ..auth_tools.auth_decorator import login_required
+from ..models import User
 from ..views.private import Private
 
 
 class AuthDecorator(TestCase):
     def setUp(self):
         self.client = Client()
-        self.factory = RequestFactory()
+        self.username = f"{rstr(letters(), 5, 50)}@{rstr(letters(), 4, 40)}.com"
+        self.password = f"{rstr(nonwhitespace(), 7, 60)}"
+        self.user = User.objects.create(username=self.username, password=self.password)
+        self.payload = {"username": self.username, "password": self.password}
 
     def test_get_private_endpoint_responds_403_status_code(self):
-        get_request_private = login_required(self.factory.get('/accounts/private'))
+        get_request_private = self.client.get(reverse("private"), self.payload,
+                                               content_type="application/json")
         self.assertEqual(get_request_private.status_code, 403)
+        self.assertEqual(get_request_private.content.decode(),
+                         json.dumps({"error": ["Forbidden."]}))
+
+    def test_get_private_endpoint_responds_200_status_code_if_valid_token_set(self):
+        valid_signin_response = self.client.post(reverse("sign_in"), self.payload,
+                                                 content_type="application/json")
+        valid_access_token = valid_signin_response._headers.get("access_token")[1]
+        post_request_private = self.client.post(reverse("private"),
+                                                {"access_token": valid_access_token},
+                                                content_type="application/json")
+        self.assertEqual(post_request_private.status_code, 200)
+        self.assertEqual(post_request_private.content.decode(),
+                         json.dumps({"username": 1}))
+
+    

--- a/accounts/tests/test_auth_decorator.py
+++ b/accounts/tests/test_auth_decorator.py
@@ -1,10 +1,15 @@
-from django.test import Client, TestCase
-from django.core.signing import Signer
+from django.test import Client, TestCase, RequestFactory
+from django.urls import reverse
 
-from ..models import User
-from ..auth_tools.auth_jwt import _generate_token
 from ..auth_tools.auth_decorator import login_required
+from ..views.private import Private
 
 
 class AuthDecorator(TestCase):
-    pass
+    def setUp(self):
+        self.client = Client()
+        self.factory = RequestFactory()
+
+    def test_get_private_endpoint_responds_403_status_code(self):
+        get_request_private = login_required(self.factory.get('/accounts/private'))
+        self.assertEqual(get_request_private.status_code, 403)

--- a/accounts/tests/test_auth_decorator.py
+++ b/accounts/tests/test_auth_decorator.py
@@ -17,12 +17,11 @@ class AuthDecorator(TestCase):
         self.user = User.objects.create(username=self.username, password=self.password)
         self.payload = {"username": self.username, "password": self.password}
 
-    def test_get_private_endpoint_responds_403_status_code(self):
+    def test_get_private_endpoint_responds_401_status_code_if_no_valid_token_set(self):
         get_request_private = self.client.get(reverse("private"), self.payload,
                                                content_type="application/json")
-        self.assertEqual(get_request_private.status_code, 403)
-        self.assertEqual(get_request_private.content.decode(),
-                         json.dumps({"error": ["Forbidden."]}))
+        self.assertEqual(get_request_private.status_code, 401)
+
 
     def test_get_private_endpoint_responds_200_status_code_if_valid_token_set(self):
         valid_signin_response = self.client.post(reverse("sign_in"), self.payload,

--- a/accounts/views/private.py
+++ b/accounts/views/private.py
@@ -1,15 +1,16 @@
 from django.views import View
 from django.http import JsonResponse
-from django.contrib.auth.decorators import login_required
+from django.utils.decorators import method_decorator
 
-from ..auth_tools import auth_decorator
-
+from ..auth_tools.auth_decorator import login_required
 
 class Private(View):
+    @login_required
     def get(self, request):
-        response = JsonResponse({"get_private": "ok"})
+        response = JsonResponse({"private_endpoint": "ok"})
         return response
 
+    @login_required
     def post(self, request):
         user = request.user
         response = JsonResponse({"username": user})

--- a/accounts/views/sign_in.py
+++ b/accounts/views/sign_in.py
@@ -11,6 +11,10 @@ from ..forms import SignInForm
 
 
 class SignIn(View):
+    def get(self, request):
+        response = JsonResponse({"get signin form": "ok"})
+        return response
+
     def post(self, request):
         try:
             form = SignInForm(json.loads(request.body.decode()))

--- a/bobloblaw/settings/base.py
+++ b/bobloblaw/settings/base.py
@@ -22,6 +22,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = config("SECRET_KEY")
+DJANGO_SETTINGS_MODULE = config("DJANGO_SETTINGS_MODULE")
 
 # Application definition
 


### PR DESCRIPTION
**What was changed**:
Private endpoints must be protected, i.e. a user that carries no JWT or an invalid one must be prevented from getting status code 200 responses.
Before this PR, the auth_middleware did a process that checked if the endpoint was "signin" or "signup" (the only public ones so far). If not, the request would be checked for the existence and validity of JWT.
Non-existent user, invalid or expired signature and no JWT at all were handled in this middleware, responding a 401 status code with the description of the error in a json.
Now, it does not check if the endpoint is public one, it just tries to fetch the JWT, and if it can't, the exception is handled just by setting an attribute for request: `request.user = None`. Then the middleware chain goes on.
This way, a decorator can be used in every private endpoint so its request will be checked for the existence of the `user` attribute. If not, there will be a response with status code 401.
Now there's no need to keep track of public endpoints in auth_middleware anymore, since the private ones will explicitly use the `@login_required` decorator.

**Conclusion**:
The responsibility of the _auth_middleware_ is now to check the existence and validation of the JWT only; if positive, the request will have an `user` attribute set to `user.id`; else, the request will have an **user** attribute set to `None`.
The responsibility of the _auth_decorator_ is to protect private endpoints; i.e. indicate which ones must be accessed only by authenticated users. And for doing that it will check the request's `user` attribute set by the auth_middleware.